### PR TITLE
chore: (dependabot): move back to npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,23 @@
+# Moving back to npm for package management rather than bun
+# because wow dependabot is so broken for it 😭
+# TODO: Labels on package updates after project restructure
+
 version: 2
 updates:
-  - package-ecosystem: "bun"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    assignees:
-      - "GalvinPython"
     target-branch: "dev"
 
-  - package-ecosystem: "bun"
+  - package-ecosystem: "npm"
     directory: "/web"
     schedule:
       interval: "weekly"
-    assignees:
-      - "GalvinPython"
     target-branch: "dev"
-    labels: ["dependencies", "javascript", "component: web"]
 
   - package-ecosystem: "cargo"
     directory: "/api"
     schedule:
       interval: "weekly"
+    target-branch: "dev"

--- a/.github/workflows/dependabot_bun.yml
+++ b/.github/workflows/dependabot_bun.yml
@@ -3,9 +3,6 @@ name: Update bun.lock
 on:
   pull_request:
     branches: [main, dev]
-    paths:
-      - "bun.lock"
-      - "package.json"
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot_bun.yml
+++ b/.github/workflows/dependabot_bun.yml
@@ -3,6 +3,9 @@ name: Update bun.lock
 on:
   pull_request:
     branches: [main, dev]
+    paths:
+      - "bun.lock"
+      - "package.json"
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot_bun.yml
+++ b/.github/workflows/dependabot_bun.yml
@@ -1,0 +1,44 @@
+name: Update bun.lock
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+permissions:
+  contents: write
+
+jobs:
+  update-bun-lock:
+    name: "Update bun.lock"
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies with Bun
+        run: bun install
+
+      - name: Check for changes
+        id: git_status
+        run: |
+          git add bun.lock
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to bun.lock"
+            echo "changes_detected=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected to bun.lock"
+            echo "changes_detected=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push changes to bun.lock
+        if: steps.git_status.outputs.changes_detected == 'true'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m "Update bun.lock (via GitHub Actions)"
+          git pull --rebase origin ${{ github.head_ref }}
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,14 +12,6 @@ on:
       - "**/*.mjs"
   pull_request:
     types: [opened, reopened, synchronize]
-    branches:
-      - "*"
-    paths:
-      - "**/*.js"
-      - "**/*.jsx"
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.mjs"
 
 jobs:
   lint:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,6 +12,14 @@ on:
       - "**/*.mjs"
   pull_request:
     types: [opened, reopened, synchronize]
+    branches:
+      - "*"
+    paths:
+      - "**/*.js"
+      - "**/*.jsx"
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.mjs"
 
 jobs:
   lint:


### PR DESCRIPTION
Dependabot has issues with bun, so this is moving back to npm. Also

- Removes me as assignee (codeowners)
- Updates `bun.lock` using actions (yay thats back again)
- Removes labels so that it doesn't break for when I restructure the repo